### PR TITLE
Add in‑memory SQLite testing & DB + integration tests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,13 +10,17 @@ from playhouse.shortcuts import model_to_dict
 load_dotenv()
 app = Flask(__name__)
 
-mydb = MySQLDatabase(
-    os.getenv("MYSQL_DATABASE"),
-    user=os.getenv("MYSQL_USER"),
-    password=os.getenv("MYSQL_PASSWORD"),
-    host=os.getenv("MYSQL_HOST"),
-    port=3306
-)
+if os.getenv("TESTING") == "true":
+    print("RUNNING IN TEST MODE")
+    mydb = SqliteDatabase('file:memory?mode=memory&cache=shared&uri=true')
+else:
+    mydb = MySQLDatabase(
+        os.getenv("MYSQL_DATABASE"),
+        user=os.getenv("MYSQL_USER"),
+        password=os.getenv("MYSQL_PASSWORD"),
+        host=os.getenv("MYSQL_HOST"),
+        port=3306
+    )
 
 class TimeLinePost(Model):
     name = CharField()
@@ -100,9 +104,19 @@ def timeline_page():
 
 @app.route('/api/timeline_post', methods=['POST'])
 def post_timeline_post():
-    name = request.form['name']
-    email = request.form['email']
-    content = request.form['content']
+    name    = request.form.get('name',   '').strip()
+    email   = request.form.get('email',  '').strip()
+    content = request.form.get('content','').strip()
+
+    if not name:
+        return "Invalid name", 400
+
+    if not content:
+        return "Invalid content", 400
+
+    if '@' not in email or '.' not in email:
+        return "Invalid email", 400
+    
     timeline_post = TimeLinePost.create(name=name, email=email, content=content)
 
     return model_to_dict(timeline_post)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,81 @@
+import os, unittest
+
+os.environ["TESTING"] = 'true'
+
+from app import app
+
+class AppTestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+    
+    def test_home(self):
+        r = self.client.get("/")
+        assert r.status_code == 200
+        html = r.get_data(as_text=True)
+        assert "<h1>Ahmad Basyouni</h1>" in html
+
+    def test_timeline_api_get(self):
+        r = self.client.get("/api/timeline_post")
+        assert r.status_code == 200
+        assert r.is_json
+        js = r.get_json()
+        assert "timeline_posts" in js
+        assert len(js["timeline_posts"]) == 0
+    
+    def test_timeline_api_post(self):
+        """POST valid data to /api/timeline_post and then GET it back."""
+        payload = {
+            "name": "Alice",
+            "email": "alice@example.com",
+            "content": "Hey there!"
+        }
+        # 1) POST should succeed
+        r1 = self.client.post("/api/timeline_post", data=payload)
+        self.assertEqual(r1.status_code, 200)
+        obj = r1.get_json()
+        self.assertEqual(obj["name"], "Alice")
+        self.assertEqual(obj["email"], "alice@example.com")
+        self.assertEqual(obj["content"], "Hey there!")
+
+        # 2) GET now returns exactly one post, matching our payload
+        r2 = self.client.get("/api/timeline_post")
+        data = r2.get_json()
+        self.assertEqual(len(data["timeline_posts"]), 1)
+        entry = data["timeline_posts"][0]
+        self.assertEqual(entry["name"], "Alice")
+        self.assertEqual(entry["email"], "alice@example.com")
+        self.assertEqual(entry["content"], "Hey there!")
+    
+    def test_timeline_page(self):
+        """GET /timeline should render the timeline.html page."""
+        r = self.client.get("/timeline")
+        self.assertEqual(r.status_code, 200)
+        html = r.get_data(as_text=True)
+        self.assertIn("<form", html)
+        self.assertIn('name="name"', html)
+        self.assertIn('name="email"', html)
+        self.assertIn('name="content"', html)
+
+    def test_malformed_timeline_post(self):
+        # missing name → should be 400 + “Invalid name” in response
+        r = self.client.post("/api/timeline_post", data={
+            "email": "john@example.com", "content": "Hi"
+        })
+        assert r.status_code == 400
+        html = r.get_data(as_text=True)
+        assert "Invalid name" in html
+
+        # 2) empty content
+        r = self.client.post("/api/timeline_post", data={
+            "name": "John", "email": "john@example.com", "content": ""
+        })
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("Invalid content", r.get_data(as_text=True))
+
+        # 3) malformed email
+        r = self.client.post("/api/timeline_post", data={
+            "name": "John", "email": "not-an-email", "content": "Hello!"
+        })
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("Invalid email", r.get_data(as_text=True))
+

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,30 @@
+import unittest
+from peewee import *
+from app import TimeLinePost  # Import your model from the app
+
+MODELS = [TimeLinePost]
+# In-memory SQLite DB (used only for testing)
+test_db = SqliteDatabase(':memory:')
+
+class TestTimelinePost(unittest.TestCase):
+    def setUp(self):
+        # Bind the model to the test DB and create the table
+        test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
+        test_db.connect()
+        test_db.create_tables(MODELS)
+
+    def tearDown(self):
+        # Drop the table and close the DB after every test
+        test_db.drop_tables(MODELS)
+        test_db.close()
+
+    def test_timeLine_post(self):
+        first = TimeLinePost.create(name='John Doe', email='john@example.com', content='Hello')
+        assert first.id == 1
+        second = TimeLinePost.create(name='Jane Doe', email='jane@example.com', content='Hi')
+        assert second.id == 2
+        # Check the data
+        posts = list(TimeLinePost.select().order_by(TimeLinePost.id))
+        self.assertEqual(len(posts), 2)
+        self.assertEqual(posts[0].name, 'John Doe')
+        self.assertEqual(posts[1].email, 'jane@example.com')


### PR DESCRIPTION
- Switches mydb to shared in memory SQLite when TESTING=true

- Adds unit tests for TimeLinePost (auto increment IDs, field checks)

- Adds Flask integration tests (home page, API GET/POST, timeline page, malformed input errors)

- Updates POST handler to return 400 on invalid name/content/email and JSON on success